### PR TITLE
Update setup profiles and expose CMGTools/NanoAODTools clone sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Key embedded knobs include:
 - `MATCH`
 - `SRC_REMOTE`, `SRC_LOCAL`, `DST_REMOTE`, `DST_LOCAL`
 - `WORKDIR_BASE`
-- `SANDBOX_RELEASE`
+
+Each runtime profile provides:
+
+- `year`
+- `tag`
+- `cfg_name`
+- `sandbox_release`
 
 The `step`, `tag`, and `ver` variables are used to define output and work directory names. If `TESTING=True` in `skimmer/lobster_config.py`, output paths are redirected to a timestamped test location.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,21 @@ python setup.py
 ```
 This script will set up a basic CMSSW release and check out the necessary [NanoAOD skimming](https://github.com/cms-nanoAOD/nanoAOD-tools) package. The script also automatically gets the cfg and json directories from the [TopEFT/topeft Run3 branch](https://github.com/TopEFT/topeft/tree/run3_test_mmerged) repo.
 
-The repo is currently setup to automatically generate and use a `CMSSW_14_0_6` release, but can be changed to use a different release. The simplest method would be to modify the [setup.py](https://github.com/Andrew42/LobsterSkimming/blob/master/setup.py) script, re-run it, and then also update the [lobster_config_T3.py](https://github.com/anpicci/LobsterSkimming/blob/run3-mva/skimmer/skim_wrapper_T3.py) config by changing the `sandbox_location` variable.
+Setup configuration now mirrors lobster runtime profiles.
+
+At the top of `setup.py`, select `ACTIVE_SETUP_PROFILE` and fallback values in `SETUP_PROFILES`.
+Optionally, edit `setup_profiles.md` to provide external profile values loaded by `setup.py`.
+
+Each setup profile provides:
+
+- `cmssw_release`
+- `scram_arch`
+- `topeft_tag`
+- `topeft_url`
+- `cmgtools_url`
+- `cmgtools_branch`
+- `nanoaodtools_url`
+- `nanoaodtools_branch`
 
 The CMSSW release that is used to construct the environment that actually runs the skimming job does not necessarily have to match the CMSSW release that is used to provide the dependencies for the lobster program itself. So changing what CMSSW release is used for doing the actual skimming should not have to result in a change to the CMSSW release used for your lobster environment.
 
@@ -25,10 +39,30 @@ cmsenv
 conda activate lobster_env
 ## mamba activate lobster_env
 ```
-- Run the code
+- Configure `ACTIVE_PROFILE` and related knobs in `skimmer/lobster_config.py`, then run
 ```
-lobster process lobster_config_T3.py
+lobster process skimmer/lobster_config.py
 ```
 
 ### Configuring the lobster job
-The main configuration option in `lobster_config_T3.py` is the choice of the `cfg_name` variable. This should correspond to one of the cfg names from the topeft cfg files and will determine which dataset samples should be run over. The `step`, `tag`, and `ver` variables are used to define the directory names of the lobster job. If `testing=True`, then only the `step` variable will be used and the output directories will instead be changed to something of the form `$USER/{step}/test/lobster_test_{tstamp}`, where `{tstamp}` will correspond to a datetime timestamp of when the lobster job was started.
+The main configuration option in `skimmer/lobster_config.py` is now `ACTIVE_PROFILE`, which selects a coherent set of defaults:
+
+- `run2_el9_skims`: Run2-oriented defaults on EL9
+- `run3_mva_anpicci`: Run3 lepMVA defaults
+
+There are now two supported configuration paths:
+
+1. Edit embedded Python variables directly in `skimmer/lobster_config.py` (recommended for local workflow control).
+2. Edit `skimmer/lobster_profiles.md` to define profile defaults externally in a markdown file loaded by the script.
+
+Key embedded knobs include:
+
+- `ACTIVE_PROFILE`
+- `INPUT_MODE`
+- `STEP`
+- `MATCH`
+- `SRC_REMOTE`, `SRC_LOCAL`, `DST_REMOTE`, `DST_LOCAL`
+- `WORKDIR_BASE`
+- `SANDBOX_RELEASE`
+
+The `step`, `tag`, and `ver` variables are used to define output and work directory names. If `TESTING=True` in `skimmer/lobster_config.py`, output paths are redirected to a timestamped test location.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Key embedded knobs include:
 - `ACTIVE_PROFILE`
 - `INPUT_MODE`
 - `STEP`
+- `TYPE`
+- `TARGET`
 - `MATCH`
 - `SRC_REMOTE`, `SRC_LOCAL`, `DST_REMOTE`, `DST_LOCAL`
 - `WORKDIR_BASE`
@@ -67,8 +69,14 @@ Key embedded knobs include:
 Each runtime profile provides:
 
 - `year`
+- `step`
+- `type`
+- `target`
 - `tag`
 - `cfg_name`
 - `sandbox_release`
+- `default_module`
 
 The `step`, `tag`, and `ver` variables are used to define output and work directory names. If `TESTING=True` in `skimmer/lobster_config.py`, output paths are redirected to a timestamped test location.
+
+See `docs/run3_lobster_config_compatibility.md` for the compatibility checklist against the latest Run3 lobster config.

--- a/docs/run2_run3_integration.md
+++ b/docs/run2_run3_integration.md
@@ -1,0 +1,48 @@
+# Run2 + Run3 Integration Notes
+
+This branch keeps one lobster entrypoint and supports both run eras through profile defaults.
+
+## What changed from the previous PR
+
+Instead of environment-variable-driven runtime and setup knobs, configuration now uses:
+
+1. Embedded Python profile variables in `setup.py` and `skimmer/lobster_config.py`.
+2. Optional external markdown profile definitions in `setup_profiles.md` and `skimmer/lobster_profiles.md`.
+
+This keeps behavior explicit in-repo and avoids shell-env coupling.
+
+## Runtime profile selection
+
+In `skimmer/lobster_config.py`, set:
+
+- `ACTIVE_PROFILE = "run2_el9_skims"` or
+- `ACTIVE_PROFILE = "run3_mva_anpicci"`
+
+The script loads profile defaults from:
+
+- Built-in `PROFILES` dict (fallback)
+- `skimmer/lobster_profiles.md` (if present)
+
+## Setup configuration
+
+In `setup.py`, set `ACTIVE_SETUP_PROFILE` to choose the setup preset.
+
+Setup profiles are loaded from:
+
+- Built-in `SETUP_PROFILES` dict (fallback)
+- `setup_profiles.md` (if present)
+
+Each setup profile includes:
+
+- `cmssw_release`
+- `scram_arch`
+- `topeft_tag`
+- `topeft_url`
+- `cmgtools_url`
+- `cmgtools_branch`
+- `nanoaodtools_url`
+- `nanoaodtools_branch`
+
+## Merge intent
+
+Single source of truth with explicit script-level knobs and optional markdown profile file to reduce branch drift while keeping configuration easy to audit.

--- a/docs/run2_run3_integration.md
+++ b/docs/run2_run3_integration.md
@@ -26,9 +26,13 @@ The script loads profile defaults from:
 Each runtime profile includes:
 
 - `year`
+- `step`
+- `type`
+- `target`
 - `tag`
 - `cfg_name`
 - `sandbox_release`
+- `default_module`
 
 ## Setup configuration
 

--- a/docs/run2_run3_integration.md
+++ b/docs/run2_run3_integration.md
@@ -23,6 +23,13 @@ The script loads profile defaults from:
 - Built-in `PROFILES` dict (fallback)
 - `skimmer/lobster_profiles.md` (if present)
 
+Each runtime profile includes:
+
+- `year`
+- `tag`
+- `cfg_name`
+- `sandbox_release`
+
 ## Setup configuration
 
 In `setup.py`, set `ACTIVE_SETUP_PROFILE` to choose the setup preset.

--- a/docs/run3_lobster_config_compatibility.md
+++ b/docs/run3_lobster_config_compatibility.md
@@ -1,0 +1,20 @@
+# Run3 lobster config compatibility check
+
+Checked against the latest `skimmer/lobster_config.py` available from the `run3-mva-anpicci` branch on GitHub.
+
+## Supported in the integrated config
+
+- `INPUT_MODE = "dbs"` and `INPUT_MODE = "files"` dataset selection modes.
+- Local and remote storage prefixes using `PROTOCOL_LOCAL`, `PROTOCOL_REMOTE`, `SRC_*`, and `DST_*` knobs.
+- Run3 `TARGET` behavior, including `SR` mode with the opposite-sign two-lepton veto and non-`SR` mode with only the `nlep >= 2` requirement.
+- Run3 `TYPE` behavior, including dynamic config-name construction for `data` versus non-data samples when `cfg_name` is omitted from a profile.
+- Run3 default labels and paths using `{STEP}_{TARGET}`.
+- Profile-driven CMSSW sandbox release, with `run3_mva_anpicci` using `CMSSW_14_0_6`.
+- File listing diagnostics, remote command diagnostics, and output destination diagnostics.
+- Era-aware lepMVA module selection for Run2 and Run3 sample names, including the Run3 `lepMVA_2016` fallback module for unmatched sample names.
+- DBS XRootD server wiring when `INPUT_MODE == "dbs"`.
+- Advanced options from the latest Run3 config, including `threshold_for_failure=10` and `threshold_for_skipping=10`.
+
+## Compatibility notes
+
+The integrated config keeps the profile abstraction for Run2/Run3 coexistence. Run3-specific defaults live in the `run3_mva_anpicci` profile rather than as top-level global constants.

--- a/scripts/install_cmssw.sh
+++ b/scripts/install_cmssw.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Usage: ./install_cmssw.sh <install-dir> <cmssw-version> <scram-arch>
+# Usage:
+# ./install_cmssw.sh <install-dir> <cmssw-version> <scram-arch> <cmgtools-url> <cmgtools-branch> <nanoaodtools-url> <nanoaodtools-branch>
 
 set -euo pipefail
 
@@ -7,6 +8,10 @@ setup_cmssw() {
     local dir="$1"
     local cmssw_ver="$2"
     local scram_arch="$3"
+    local cmgtools_url="$4"
+    local cmgtools_branch="$5"
+    local nanoaodtools_url="$6"
+    local nanoaodtools_branch="$7"
 
     cd "${dir}" || { echo "ERROR: directory '${dir}' does not exist"; return 1; }
 
@@ -21,10 +26,11 @@ setup_cmssw() {
     echo "dir: ${dir}"
     echo "cmssw_release: ${cmssw_ver}"
     echo "SCRAM_ARCH: ${scram_arch}"
+    echo "CMGTools source: ${cmgtools_url} (${cmgtools_branch:-default branch})"
+    echo "NanoAODTools source: ${nanoaodtools_url} (${nanoaodtools_branch:-default branch})"
 
     if [[ -d "${cvmfs_dir}" ]]; then
         echo "Found CVMFS!"
-        # Makes cmsrel available to the environment
         # shellcheck source=/dev/null
         source "${cvmfs_dir}/cmsset_default.sh"
     else
@@ -38,10 +44,19 @@ setup_cmssw() {
     scram p CMSSW "${cmssw_ver}"
 
     cd "${cmssw_ver}/src"
-    #git clone git@github.com:sscruz/cmgtools-lite.git -b 104X_dev_nano_lepMVA CMGTools
-    #git clone https://github.com/jdelrieg/topEFT_ttHMVA_Run3.git -b newcmgtools_python3 CMGTools
-    git clone https://github.com/anpicci/topEFT_ttHMVA_Run3.git -b nd_run3 CMGTools
-    #git clone https://github.com/cms-nanoAOD/nanoAOD-tools.git PhysicsTools/NanoAODTools
+
+    if [[ -n "${cmgtools_branch}" ]]; then
+        git clone "${cmgtools_url}" -b "${cmgtools_branch}" CMGTools
+    else
+        git clone "${cmgtools_url}" CMGTools
+    fi
+
+    mkdir -p PhysicsTools
+    if [[ -n "${nanoaodtools_branch}" ]]; then
+        git clone "${nanoaodtools_url}" -b "${nanoaodtools_branch}" PhysicsTools/NanoAODTools
+    else
+        git clone "${nanoaodtools_url}" PhysicsTools/NanoAODTools
+    fi
 
     echo "Getting CMS ENV from ${PWD}"
     eval "$(scramv1 runtime -sh)"

--- a/setup.py
+++ b/setup.py
@@ -1,45 +1,136 @@
 import os
 import subprocess
 
+# Setup profile selection knob
+ACTIVE_SETUP_PROFILE = "run2_el9_skims"
+
+# Optional external markdown setup-profile file.
+# If present and contains ACTIVE_SETUP_PROFILE, values from there are used.
+SETUP_PROFILE_MARKDOWN_FILE = os.path.join(os.path.split(__file__)[0], "setup_profiles.md")
+
+# Fallback setup profiles (used if markdown file is absent)
+SETUP_PROFILES = {
+    "run2_el9_skims": {
+        "cmssw_release": "CMSSW_10_6_19_patch2",
+        "scram_arch": "slc7_amd64_gcc700",
+        "topeft_tag": "run3_test_mmerged",
+        "topeft_url": "https://github.com/TopEFT/topeft.git",
+        "cmgtools_url": "https://github.com/anpicci/topEFT_ttHMVA_Run3.git",
+        "cmgtools_branch": "nd_run3",
+        "nanoaodtools_url": "https://github.com/cms-nanoAOD/nanoAOD-tools.git",
+        "nanoaodtools_branch": "",
+    },
+    "run3_mva_anpicci": {
+        "cmssw_release": "CMSSW_14_0_6",
+        "scram_arch": "el9_amd64_gcc12",
+        "topeft_tag": "run3_test_mmerged",
+        "topeft_url": "https://github.com/TopEFT/topeft.git",
+        "cmgtools_url": "https://github.com/anpicci/topEFT_ttHMVA_Run3.git",
+        "cmgtools_branch": "nd_run3",
+        "nanoaodtools_url": "https://github.com/cms-nanoAOD/nanoAOD-tools.git",
+        "nanoaodtools_branch": "",
+    },
+}
+
+
+def parse_markdown_profiles(md_path):
+    """Parse a simple markdown profile file with sections and '- key: value' lines."""
+    if not os.path.exists(md_path):
+        return {}
+
+    parsed = {}
+    current = None
+    with open(md_path) as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if not line:
+                continue
+
+            if line.startswith("## "):
+                current = line[3:].strip()
+                parsed[current] = {}
+                continue
+
+            if current and line.startswith("- ") and ":" in line:
+                content = line[2:]
+                key, value = content.split(":", 1)
+                parsed[current][key.strip()] = value.strip()
+
+    return parsed
+
+
 def main():
-    top_dir, fname = os.path.split(__file__)
+    top_dir, _ = os.path.split(__file__)
     if not top_dir:
         top_dir = "."
 
     os.chdir(top_dir)
 
-    # Decode output to str
     abs_path = subprocess.check_output(
         ["git", "rev-parse", "--show-toplevel"],
-        text=True,            # or universal_newlines=True
+        text=True,
     ).strip()
 
-    cmssw_release = "CMSSW_14_0_6"
-    scram_arch = "el9_amd64_gcc12"
+    md_profiles = parse_markdown_profiles(SETUP_PROFILE_MARKDOWN_FILE)
+    if md_profiles:
+        SETUP_PROFILES.update(md_profiles)
+
+    if ACTIVE_SETUP_PROFILE not in SETUP_PROFILES:
+        raise ValueError(
+            f"Unknown ACTIVE_SETUP_PROFILE={ACTIVE_SETUP_PROFILE!r}. "
+            f"Valid profiles: {', '.join(sorted(SETUP_PROFILES))}"
+        )
+
+    profile = SETUP_PROFILES[ACTIVE_SETUP_PROFILE]
+    cmssw_release = profile["cmssw_release"]
+    scram_arch = profile["scram_arch"]
+    topeft_tag = profile["topeft_tag"]
+    topeft_url = profile["topeft_url"]
+    cmgtools_url = profile["cmgtools_url"]
+    cmgtools_branch = profile["cmgtools_branch"]
+    nanoaodtools_url = profile["nanoaodtools_url"]
+    nanoaodtools_branch = profile["nanoaodtools_branch"]
+
+    print(f"Selected ACTIVE_SETUP_PROFILE = {ACTIVE_SETUP_PROFILE}")
+    print(f"Using setup profile markdown file: {SETUP_PROFILE_MARKDOWN_FILE}")
 
     if os.path.exists("topeft"):
         print("topeft directory already installed, skipping this part\n")
     else:
         print("Installing topeft cfg and json directories")
-        topeft_url = "https://github.com/TopEFT/topeft.git"
-        tag = "run3_test_mmerged"
         prj_head = f"{abs_path}/topeft"
-        cfg_dir  = "input_samples/cfgs"
+        cfg_dir = "input_samples/cfgs"
         json_dir = "input_samples/sample_jsons"
         subprocess.check_call(
-            [f"{top_dir}/scripts/install_configs.sh",
-             topeft_url, prj_head, tag, cfg_dir, json_dir]
+            [
+                f"{top_dir}/scripts/install_configs.sh",
+                topeft_url,
+                prj_head,
+                topeft_tag,
+                cfg_dir,
+                json_dir,
+            ]
         )
         print("")
 
     if os.path.exists(cmssw_release):
-        print("CMSSW release {} detected, skipping this part".format(cmssw_release))
+        print(f"CMSSW release {cmssw_release} detected, skipping this part")
     else:
         print("Setting up CMSSW release (NANOAODtools included)")
         subprocess.check_call(
-            ["./scripts/install_cmssw.sh", abs_path, cmssw_release, scram_arch]
+            [
+                "./scripts/install_cmssw.sh",
+                abs_path,
+                cmssw_release,
+                scram_arch,
+                cmgtools_url,
+                cmgtools_branch,
+                nanoaodtools_url,
+                nanoaodtools_branch,
+            ]
         )
 
     print("\nDone!\nMake sure not to run cmsenv when you are in your conda/mamba lobster env!")
+
 
 main()

--- a/setup_profiles.md
+++ b/setup_profiles.md
@@ -1,0 +1,23 @@
+# Setup profiles
+
+This file defines setup defaults used by `setup.py`.
+
+## run2_el9_skims
+- cmssw_release: CMSSW_10_6_19_patch2
+- scram_arch: slc7_amd64_gcc700
+- topeft_tag: run3_test_mmerged
+- topeft_url: https://github.com/TopEFT/topeft.git
+- cmgtools_url: https://github.com/anpicci/topEFT_ttHMVA_Run3.git
+- cmgtools_branch: nd_run3
+- nanoaodtools_url: https://github.com/cms-nanoAOD/nanoAOD-tools.git
+- nanoaodtools_branch:
+
+## run3_mva_anpicci
+- cmssw_release: CMSSW_14_0_6
+- scram_arch: el9_amd64_gcc12
+- topeft_tag: run3_test_mmerged
+- topeft_url: https://github.com/TopEFT/topeft.git
+- cmgtools_url: https://github.com/anpicci/topEFT_ttHMVA_Run3.git
+- cmgtools_branch: nd_run3
+- nanoaodtools_url: https://github.com/cms-nanoAOD/nanoAOD-tools.git
+- nanoaodtools_branch:

--- a/skimmer/lobster_config.py
+++ b/skimmer/lobster_config.py
@@ -35,7 +35,6 @@ SRC_LOCAL = "/cms/cephfs/data"
 DST_REMOTE = "cmsxrootd.crc.nd.edu"
 DST_LOCAL = "/cms/cephfs/data"
 WORKDIR_BASE = "/tmpscratch/users/$USER"
-SANDBOX_RELEASE = "CMSSW_14_0_6"
 
 # Fallback profile defaults (used if markdown file is absent)
 PROFILES = {
@@ -43,11 +42,13 @@ PROFILES = {
         "year": "2018",
         "tag": "data/NAOD_ULv12_lepMVA-run2/2018",
         "cfg_name": "ND_UL18_background_samples.cfg",
+        "sandbox_release": "CMSSW_10_6_19_patch2",
     },
     "run3_mva_anpicci": {
         "year": "2022",
         "tag": "data/NAOD_ULv12_lepMVA-run3/2022",
         "cfg_name": "ND_2022_background_samples.cfg",
+        "sandbox_release": "CMSSW_14_0_6",
     },
 }
 
@@ -122,6 +123,7 @@ profile_cfg = PROFILES[ACTIVE_PROFILE]
 YEAR = profile_cfg["year"]
 TAG = profile_cfg["tag"]
 CFG_NAME = profile_cfg["cfg_name"]
+SANDBOX_RELEASE = profile_cfg["sandbox_release"]
 
 
 # =============================================================================

--- a/skimmer/lobster_config.py
+++ b/skimmer/lobster_config.py
@@ -27,6 +27,8 @@ INPUT_MODE = "files"  # "dbs" or "files"
 PROTOCOL_LOCAL = "file://"
 PROTOCOL_REMOTE = "root://"
 STEP = "skims"
+TYPE = "background"
+TARGET = "SR"
 MATCH = []  # e.g. [r".*TTLL\_MLL-50.*\.json"]
 
 # XRootD endpoints
@@ -40,24 +42,26 @@ WORKDIR_BASE = "/tmpscratch/users/$USER"
 PROFILES = {
     "run2_el9_skims": {
         "year": "2018",
+        "step": "skims",
+        "type": "background",
+        "target": "SR",
         "tag": "data/NAOD_ULv12_lepMVA-run2/2018",
         "cfg_name": "ND_UL18_background_samples.cfg",
         "sandbox_release": "CMSSW_10_6_19_patch2",
+        "default_module": "lepMVA_2018",
     },
     "run3_mva_anpicci": {
-        "year": "2022",
-        "tag": "data/NAOD_ULv12_lepMVA-run3/2022",
-        "cfg_name": "ND_2022_background_samples.cfg",
+        "year": "2023BPix",
+        "step": "skimmed",
+        "type": "background",
+        "target": "SR",
+        "tag": "background/NAOD_ULv12_lepMVA-run3/2023BPix",
+        "cfg_name": "ND_2023BPix_background_samples.cfg",
         "sandbox_release": "CMSSW_14_0_6",
+        "default_module": "lepMVA_2016",
     },
 }
 
-SKIM_CUT = (
-    " nMuon+nElectron+nTau >=2 && "
-    "Sum$( Muon_looseId && Muon_miniPFRelIso_all<0.4 && Muon_sip3d<8 ) + "
-    "Sum$( Electron_miniPFRelIso_all<0.4 && Electron_sip3d<8 ) + "
-    "Sum$( Tau_idDeepTau2018v2p5VSe>1 && Tau_idDeepTau2018v2p5VSmu>0 && Tau_idDeepTau2018v2p5VSjet>1 ) >=2 "
-)
 WRAPPER = "skim_wrapper.py"
 
 
@@ -90,7 +94,41 @@ def parse_markdown_profiles(md_path):
     return parsed
 
 
-def pick_module(sample_name, active_profile):
+def default_tag(sample_type, year, active_profile):
+    if active_profile == "run3_mva_anpicci":
+        return f"{sample_type}/NAOD_ULv12_lepMVA-run3/{year}"
+    return f"data/NAOD_ULv12_lepMVA-run2/{year}"
+
+
+def default_cfg_name(sample_type, year):
+    if sample_type == "data":
+        return f"{year}_data.cfg"
+    return f"ND_{year}_{sample_type}_samples.cfg"
+
+
+def make_skim_cut(target):
+    el_req = (
+        "Electron_pt>10 && Electron_miniPFRelIso_all<0.4 && Electron_sip3d<8 && "
+        "(abs(Electron_eta + Electron_deltaEtaSC) < 1.4442 || "
+        "abs(Electron_eta + Electron_deltaEtaSC) > 1.566)"
+    )
+    mu_req = "Muon_pt>10 && Muon_looseId && Muon_miniPFRelIso_all<0.4 && Muon_sip3d<8"
+    ta_req = (
+        "Tau_pt>20 && Tau_dxy<0.05 && Tau_dz<1 && "
+        "Tau_idDeepTau2018v2p5VSe>1 && Tau_idDeepTau2018v2p5VSmu>3 && "
+        "Tau_idDeepTau2018v2p5VSjet>2"
+    )
+    num_leps = f"(Sum$({el_req}) + Sum$({mu_req}) + Sum$({ta_req}))"
+    net_charge = (
+        f"(Sum$(Electron_charge*({el_req})) + Sum$(Muon_charge*({mu_req})) + "
+        f"Sum$(Tau_charge*({ta_req})))"
+    )
+    os2l_veto = f"(({num_leps} != 2) || ({net_charge} != 0))"
+    nlep_req = f"({num_leps} >= 2)"
+    return f"{nlep_req} && {os2l_veto}" if target == "SR" else nlep_req
+
+
+def pick_module(sample_name, default_module):
     if "HIPM_UL2016" in sample_name:
         return "lepMVA_2016_preVFP"
     if "UL2016" in sample_name:
@@ -101,7 +139,7 @@ def pick_module(sample_name, active_profile):
         return "lepMVA_2018"
     if "2022" in sample_name or "2023" in sample_name:
         return "lepMVA"
-    return "lepMVA_2018" if active_profile == "run2_el9_skims" else "lepMVA"
+    return default_module
 
 
 # =============================================================================
@@ -121,9 +159,14 @@ if INPUT_MODE not in ("dbs", "files"):
 
 profile_cfg = PROFILES[ACTIVE_PROFILE]
 YEAR = profile_cfg["year"]
-TAG = profile_cfg["tag"]
-CFG_NAME = profile_cfg["cfg_name"]
+STEP = profile_cfg.get("step", STEP)
+TYPE = profile_cfg.get("type", TYPE)
+TARGET = profile_cfg.get("target", TARGET)
+TAG = profile_cfg.get("tag", default_tag(TYPE, YEAR, ACTIVE_PROFILE))
+CFG_NAME = profile_cfg.get("cfg_name", default_cfg_name(TYPE, YEAR))
 SANDBOX_RELEASE = profile_cfg["sandbox_release"]
+DEFAULT_MODULE = profile_cfg.get("default_module", "lepMVA_2016")
+SKIM_CUT = make_skim_cut(TARGET)
 
 
 # =============================================================================
@@ -138,24 +181,34 @@ TSTAMP1 = datetime.datetime.now().strftime("%Y%m%d_%H%M")
 startingday = datetime.datetime.now().strftime("%y%m%d")
 ver = f"v{startingday}"
 
-top_dir = subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode("utf-8").strip()
-sandbox_location = os.path.join(top_dir, SANDBOX_RELEASE)
-cfg_fpath = os.path.join(top_dir, "topeft", "input_samples", "cfgs", CFG_NAME)
+try:
+    top_dir = subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode("utf-8").strip()
+    sandbox_location = os.path.join(top_dir, SANDBOX_RELEASE)
+    cfg_fpath = os.path.join(top_dir, "topeft", "input_samples", "cfgs", CFG_NAME)
+except Exception as e:
+    print("Error while determining top-level directory or cfg file path.")
+    print("Please check your git repository and configuration.")
+    print("Error details:")
+    print(e)
+    raise Exception("Failed to set up configuration due to the above error.")
 
 mode_stamp = INPUT_MODE
-master_label = f"{STEP}_{ACTIVE_PROFILE}_{mode_stamp}_lobPY3_{TSTAMP1}"
-workdir_path = f"{WORKDIR_BASE}/{STEP}/{TAG}/{ver}"
-plotdir_path = f"~/www/lobster/{STEP}/{TAG}/{ver}"
-output_path = f"/store/user/$USER/{STEP}/{TAG}/{ver}"
+step_label = f"{STEP}_{TARGET}" if TARGET else STEP
+master_label = f"{step_label}_{ACTIVE_PROFILE}_{mode_stamp}_lobPY3_{TSTAMP1}"
+workdir_path = f"{WORKDIR_BASE}/{step_label}/{TAG}/{ver}"
+plotdir_path = f"~/www/lobster/{step_label}/{TAG}/{ver}"
+output_path = f"/store/user/$USER/{step_label}/{TAG}/{ver}"
 
 if TESTING:
-    master_label = f"{STEP}_{ACTIVE_PROFILE}_{mode_stamp}_testlobPY3_{TSTAMP1}"
-    workdir_path = f"{WORKDIR_BASE}/{STEP}/test/lobster_skimtest_{TSTAMP1}"
-    plotdir_path = f"~/www/lobster/{STEP}/test/lobster_skimtest_{TSTAMP1}"
-    output_path = f"/store/user/$USER/{STEP}/test/lobster_skimtest_{TSTAMP1}"
+    master_label = f"{step_label}_{ACTIVE_PROFILE}_{mode_stamp}_testlobPY3_{TSTAMP1}"
+    workdir_path = f"{WORKDIR_BASE}/{step_label}/test/lobster_skimtest_{TSTAMP1}"
+    plotdir_path = f"~/www/lobster/{step_label}/test/lobster_skimtest_{TSTAMP1}"
+    output_path = f"/store/user/$USER/{step_label}/test/lobster_skimtest_{TSTAMP1}"
 
 print(f"Selected ACTIVE_PROFILE = {ACTIVE_PROFILE}")
 print(f"Using profile markdown file: {PROFILE_MARKDOWN_FILE}")
+print(f"TYPE = {TYPE}")
+print(f"TARGET = {TARGET}")
 print(f"Sandbox location: {sandbox_location}")
 print(f"Where is your cfg?\t {cfg_fpath}")
 print(f"INPUT_MODE = {INPUT_MODE}")
@@ -163,6 +216,8 @@ print(f"SRC_PREFIX_LOCAL = {SRC_PREFIX_LOCAL}")
 print(f"SRC_PREFIX_REMOTE = {SRC_PREFIX_REMOTE}")
 print(f"DST_PREFIX_LOCAL = {DST_PREFIX_LOCAL}")
 print(f"DST_PREFIX_REMOTE = {DST_PREFIX_REMOTE}")
+print(f"{DST_PREFIX_LOCAL}{output_path}", "\n")
+print(f"{DST_PREFIX_REMOTE}{output_path}", "\n")
 
 
 # =============================================================================
@@ -185,53 +240,65 @@ storage = storage_dbs if INPUT_MODE == "dbs" else storage_files
 # =============================================================================
 # WORKFLOWS
 # =============================================================================
-cfg = read_cfg(cfg_fpath, match=MATCH)
-print("cfg jsons:", list(cfg["jsons"].keys()))
+try:
+    cfg = read_cfg(cfg_fpath, match=MATCH)
+    print("cfg jsons:", list(cfg["jsons"].keys()))
 
-cat = Category(name="processing", cores=1, memory=1500, disk=4500)
-skim_cut = SKIM_CUT.replace(" ", "")
+    cat = Category(name="processing", cores=1, memory=1500, disk=4500)
+    skim_cut = SKIM_CUT.replace(" ", "")
 
-wf = []
-for sample in sorted(cfg["jsons"]):
-    jsn = cfg["jsons"][sample]
-    print(f"Processing sample: {sample}")
+    wf = []
+    for sample in sorted(cfg["jsons"]):
+        jsn = cfg["jsons"][sample]
+        print(f"Processing sample: {sample}")
+        for fn in jsn["files"]:
+            print(f"  {fn}")
 
-    files = [x for x in jsn["files"]]
-    module_name = pick_module(sample, ACTIVE_PROFILE)
+        files = [x for x in jsn["files"]]
+        module_name = pick_module(sample, DEFAULT_MODULE)
 
-    if INPUT_MODE == "dbs":
-        ds = cmssw.Dataset(
-            dataset=jsn["path"],
-            lumis_per_task=1,
-            file_based=True,
+        if INPUT_MODE == "dbs":
+            ds = cmssw.Dataset(
+                dataset=jsn["path"],
+                lumis_per_task=1,
+                file_based=True,
+            )
+        else:
+            ds = Dataset(
+                files=files,
+                files_per_task=1,
+                patterns=["*.root"],
+            )
+
+        cmd = ["python3", WRAPPER]
+        cmd += ["--cut", skim_cut]
+        cmd += ["--module", module_name]
+        cmd += ["--out-dir", "."]
+        cmd += ["@inputfiles"]
+
+        print("\nRemote command:\n", " ".join(cmd), "\n")
+
+        skim_wf = Workflow(
+            label=sample.replace("-", "_"),
+            sandbox=cmssw.Sandbox(release=sandbox_location),
+            dataset=ds,
+            category=cat,
+            extra_inputs=[WRAPPER],
+            outputs=["output.root"],
+            command=" ".join(cmd),
+            merge_command="haddnano.py @outputfiles @inputfiles",
+            merge_size="537M",
+            globaltag=False,
+            cleanup_input=False,
         )
-    else:
-        ds = Dataset(
-            files=files,
-            files_per_task=1,
-            patterns=["*.root"],
-        )
-
-    cmd = ["python3", WRAPPER]
-    cmd += ["--cut", skim_cut]
-    cmd += ["--module", module_name]
-    cmd += ["--out-dir", "."]
-    cmd += ["@inputfiles"]
-
-    skim_wf = Workflow(
-        label=sample.replace("-", "_"),
-        sandbox=cmssw.Sandbox(release=sandbox_location),
-        dataset=ds,
-        category=cat,
-        extra_inputs=[WRAPPER],
-        outputs=["output.root"],
-        command=" ".join(cmd),
-        merge_command="haddnano.py @outputfiles @inputfiles",
-        merge_size="537M",
-        globaltag=False,
-        cleanup_input=False,
-    )
-    wf.append(skim_wf)
+        wf.append(skim_wf)
+except Exception as e:
+    print("Error while setting up workflows.")
+    print("Please check your configuration and try again.")
+    print("Error details:")
+    print(e)
+    wf = []
+    raise Exception("Failed to set up workflows due to the above error.")
 
 
 # =============================================================================
@@ -242,8 +309,8 @@ adv_kwargs = dict(
     log_level=1,
     payload=10,
     osg_version="3.6",
-    threshold_for_failure=1,
-    threshold_for_skipping=1,
+    threshold_for_failure=10,
+    threshold_for_skipping=10,
 )
 
 if INPUT_MODE == "dbs":

--- a/skimmer/lobster_config.py
+++ b/skimmer/lobster_config.py
@@ -15,25 +15,41 @@ from tools.utils import read_cfg
 # =============================================================================
 TESTING = False
 
-# Choose one:
-#   "dbs"   -> cmssw.Dataset(dataset=..., file_based=True) + advanced.xrootd_servers
-#   "files" -> Dataset(files=...) + StorageConfiguration(input=[root://...//])
-INPUT_MODE = "files"
+# Primary selection knob (embedded Python variable, no env var needed)
+ACTIVE_PROFILE = "run2_el9_skims"
 
-# Choose one protocol:
-#   "root://"  # used for remote XRootD paths
-#   "file://"  # used for local CephFS paths
-PROTOCOL_LOCAL  = "file://"
+# Optional external markdown profile file.
+# If this file exists and defines ACTIVE_PROFILE, those values are used.
+PROFILE_MARKDOWN_FILE = os.path.join(os.path.split(__file__)[0], "lobster_profiles.md")
+
+# Runtime knobs
+INPUT_MODE = "files"  # "dbs" or "files"
+PROTOCOL_LOCAL = "file://"
 PROTOCOL_REMOTE = "root://"
-
-YEAR = "2022"
 STEP = "skims"
-TAG = f"data/NAOD_ULv12_lepMVA-run3/{YEAR}"  # not used in TESTING mode
-CFG_NAME = f"ND_{YEAR}_background_samples.cfg"
+MATCH = []  # e.g. [r".*TTLL\_MLL-50.*\.json"]
 
-# Only process json files that match these regexs (empty list matches everything)
-# MATCH = [r".*TTLL\_MLL-50.*\.json"]
-MATCH = []
+# XRootD endpoints
+SRC_REMOTE = "cmsxrootd.crc.nd.edu"
+SRC_LOCAL = "/cms/cephfs/data"
+DST_REMOTE = "cmsxrootd.crc.nd.edu"
+DST_LOCAL = "/cms/cephfs/data"
+WORKDIR_BASE = "/tmpscratch/users/$USER"
+SANDBOX_RELEASE = "CMSSW_14_0_6"
+
+# Fallback profile defaults (used if markdown file is absent)
+PROFILES = {
+    "run2_el9_skims": {
+        "year": "2018",
+        "tag": "data/NAOD_ULv12_lepMVA-run2/2018",
+        "cfg_name": "ND_UL18_background_samples.cfg",
+    },
+    "run3_mva_anpicci": {
+        "year": "2022",
+        "tag": "data/NAOD_ULv12_lepMVA-run3/2022",
+        "cfg_name": "ND_2022_background_samples.cfg",
+    },
+}
 
 SKIM_CUT = (
     " nMuon+nElectron+nTau >=2 && "
@@ -41,101 +57,123 @@ SKIM_CUT = (
     "Sum$( Electron_miniPFRelIso_all<0.4 && Electron_sip3d<8 ) + "
     "Sum$( Tau_idDeepTau2018v2p5VSe>1 && Tau_idDeepTau2018v2p5VSmu>0 && Tau_idDeepTau2018v2p5VSjet>1 ) >=2 "
 )
+WRAPPER = "skim_wrapper.py"
 
-WRAPPER = "skim_wrapper.py"  # keep T3 wrapper behavior, single file
-
-# XRootD endpoints (T3 defaults)
-## Different xrd src redirectors depending on where the inputs are stored
-# SRC = "cmsxcache.crc.nd.edu"          # To read ND T3 files from outside of ND T3 (like the opportunistic resources)
-# SRC = "cms-xrd-global.cern.ch"          # To read remote files (global redirector)
-SRC_REMOTE = "cmsxrootd.crc.nd.edu"            # To read ND T3 files from ND T3 via XRootD
-SRC_LOCAL = "/cms/cephfs/data" # if PROTOCOL == "file://" else SRC  # Local CephFS access
-DST_REMOTE = "cmsxrootd.crc.nd.edu"            # To write to ND T3
-DST_LOCAL = "/cms/cephfs/data" # if PROTOCOL == "file://" else DST  # Local CephFS access
-
-# if SRC.startswith("/cms/cephfs/data") and PROTOCOL != "file://":
-#     raise ValueError("When using CephFS local path for SRC, PROTOCOL must be 'file://'")
-# elif not SRC.startswith("/cms/cephfs/data") and PROTOCOL != "root://":
-#     raise ValueError("When using remote XRootD path for SRC, PROTOCOL must be 'root://'")
-
-# if DST.startswith("/cms/cephfs/data") and PROTOCOL != "file://":
-#     raise ValueError("When using CephFS local path for DST, PROTOCOL must be 'file://'")
-# elif not DST.startswith("/cms/cephfs/data") and PROTOCOL != "root://":
-#     raise ValueError("When using remote XRootD path for DST, PROTOCOL must be 'root://'")
-
-SRC_PREFIX_LOCAL = PROTOCOL_LOCAL + SRC_LOCAL + "//"
-DST_PREFIX_LOCAL = PROTOCOL_LOCAL + DST_LOCAL + "//"
-
-SRC_PREFIX_REMOTE = PROTOCOL_REMOTE + SRC_REMOTE + "//"
-DST_PREFIX_REMOTE = PROTOCOL_REMOTE + DST_REMOTE + "//"
-
-# Workdir base (your choice)
-WORKDIR_BASE = "/tmpscratch/users/$USER"
 
 # =============================================================================
-# VALIDATION
+# HELPERS
 # =============================================================================
-INPUT_MODE = INPUT_MODE.strip().lower()
+def parse_markdown_profiles(md_path):
+    """Parse a simple markdown profile file with sections and '- key: value' lines."""
+    if not os.path.exists(md_path):
+        return {}
+
+    parsed = {}
+    current = None
+    with open(md_path) as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if not line:
+                continue
+
+            if line.startswith("## "):
+                current = line[3:].strip()
+                parsed[current] = {}
+                continue
+
+            if current and line.startswith("- ") and ":" in line:
+                content = line[2:]
+                key, value = content.split(":", 1)
+                parsed[current][key.strip()] = value.strip()
+
+    return parsed
+
+
+def pick_module(sample_name, active_profile):
+    if "HIPM_UL2016" in sample_name:
+        return "lepMVA_2016_preVFP"
+    if "UL2016" in sample_name:
+        return "lepMVA_2016"
+    if "UL2017" in sample_name:
+        return "lepMVA_2017"
+    if "UL2018" in sample_name:
+        return "lepMVA_2018"
+    if "2022" in sample_name or "2023" in sample_name:
+        return "lepMVA"
+    return "lepMVA_2018" if active_profile == "run2_el9_skims" else "lepMVA"
+
+
+# =============================================================================
+# PROFILE SELECTION / VALIDATION
+# =============================================================================
+md_profiles = parse_markdown_profiles(PROFILE_MARKDOWN_FILE)
+if md_profiles:
+    PROFILES.update(md_profiles)
+
+if ACTIVE_PROFILE not in PROFILES:
+    raise ValueError(
+        f"Unknown ACTIVE_PROFILE={ACTIVE_PROFILE!r}. Valid profiles: {', '.join(sorted(PROFILES))}"
+    )
+
 if INPUT_MODE not in ("dbs", "files"):
     raise ValueError(f"INPUT_MODE must be 'dbs' or 'files', got: {INPUT_MODE!r}")
+
+profile_cfg = PROFILES[ACTIVE_PROFILE]
+YEAR = profile_cfg["year"]
+TAG = profile_cfg["tag"]
+CFG_NAME = profile_cfg["cfg_name"]
 
 
 # =============================================================================
 # DERIVED PATHS / LABELS
 # =============================================================================
+SRC_PREFIX_LOCAL = PROTOCOL_LOCAL + SRC_LOCAL + "//"
+DST_PREFIX_LOCAL = PROTOCOL_LOCAL + DST_LOCAL + "//"
+SRC_PREFIX_REMOTE = PROTOCOL_REMOTE + SRC_REMOTE + "//"
+DST_PREFIX_REMOTE = PROTOCOL_REMOTE + DST_REMOTE + "//"
+
 TSTAMP1 = datetime.datetime.now().strftime("%Y%m%d_%H%M")
 startingday = datetime.datetime.now().strftime("%y%m%d")
 ver = f"v{startingday}"
 
 top_dir = subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode("utf-8").strip()
-
-# Portable sandbox
-sandbox_location = os.path.join(top_dir, "CMSSW_14_0_6")
-print(f"Sandbox location: {sandbox_location}")
-
+sandbox_location = os.path.join(top_dir, SANDBOX_RELEASE)
 cfg_fpath = os.path.join(top_dir, "topeft", "input_samples", "cfgs", CFG_NAME)
-print(f"Where is your cfg?\t {cfg_fpath}")
 
 mode_stamp = INPUT_MODE
-master_label = f"{STEP}_{mode_stamp}_lobPY3_{TSTAMP1}"
+master_label = f"{STEP}_{ACTIVE_PROFILE}_{mode_stamp}_lobPY3_{TSTAMP1}"
 workdir_path = f"{WORKDIR_BASE}/{STEP}/{TAG}/{ver}"
 plotdir_path = f"~/www/lobster/{STEP}/{TAG}/{ver}"
-output_path  = f"/store/user/$USER/{STEP}/{TAG}/{ver}"
+output_path = f"/store/user/$USER/{STEP}/{TAG}/{ver}"
 
 if TESTING:
-    master_label = f"{STEP}_{mode_stamp}_testlobPY3_{TSTAMP1}"
+    master_label = f"{STEP}_{ACTIVE_PROFILE}_{mode_stamp}_testlobPY3_{TSTAMP1}"
     workdir_path = f"{WORKDIR_BASE}/{STEP}/test/lobster_skimtest_{TSTAMP1}"
     plotdir_path = f"~/www/lobster/{STEP}/test/lobster_skimtest_{TSTAMP1}"
-    output_path  = f"/store/user/$USER/{STEP}/test/lobster_skimtest_{TSTAMP1}"
+    output_path = f"/store/user/$USER/{STEP}/test/lobster_skimtest_{TSTAMP1}"
 
+print(f"Selected ACTIVE_PROFILE = {ACTIVE_PROFILE}")
+print(f"Using profile markdown file: {PROFILE_MARKDOWN_FILE}")
+print(f"Sandbox location: {sandbox_location}")
+print(f"Where is your cfg?\t {cfg_fpath}")
 print(f"INPUT_MODE = {INPUT_MODE}")
 print(f"SRC_PREFIX_LOCAL = {SRC_PREFIX_LOCAL}")
 print(f"SRC_PREFIX_REMOTE = {SRC_PREFIX_REMOTE}")
 print(f"DST_PREFIX_LOCAL = {DST_PREFIX_LOCAL}")
 print(f"DST_PREFIX_REMOTE = {DST_PREFIX_REMOTE}")
-print(f"{DST_PREFIX_LOCAL}{output_path}", "\n")
-print(f"{DST_PREFIX_REMOTE}{output_path}", "\n")
 
 
 # =============================================================================
 # STORAGE (mode-dependent)
 # =============================================================================
 storage_dbs = StorageConfiguration(
-    output=[
-        f"{DST_PREFIX_REMOTE}{output_path}",
-    ],
+    output=[f"{DST_PREFIX_REMOTE}{output_path}"],
     disable_input_streaming=False,
 )
 
 storage_files = StorageConfiguration(
-    input=[
-        f"{SRC_PREFIX_LOCAL}",
-        f"{SRC_PREFIX_REMOTE}"
-    ],
-    output=[
-        f"{DST_PREFIX_LOCAL}{output_path}",
-        f"{DST_PREFIX_REMOTE}{output_path}",
-    ],
+    input=[f"{SRC_PREFIX_LOCAL}", f"{SRC_PREFIX_REMOTE}"],
+    output=[f"{DST_PREFIX_LOCAL}{output_path}", f"{DST_PREFIX_REMOTE}{output_path}"],
     disable_input_streaming=False,
 )
 
@@ -149,36 +187,20 @@ cfg = read_cfg(cfg_fpath, match=MATCH)
 print("cfg jsons:", list(cfg["jsons"].keys()))
 
 cat = Category(name="processing", cores=1, memory=1500, disk=4500)
-
 skim_cut = SKIM_CUT.replace(" ", "")
 
 wf = []
 for sample in sorted(cfg["jsons"]):
     jsn = cfg["jsons"][sample]
     print(f"Processing sample: {sample}")
-    for fn in jsn["files"]:
-        print(f"  {fn}")
 
-    # keep only this (your decision h)
     files = [x for x in jsn["files"]]
+    module_name = pick_module(sample, ACTIVE_PROFILE)
 
-    # module selection (bug-fixed)
-    if "HIPM_UL2016" in sample:
-        module_name = "lepMVA_2016_preVFP"
-    elif "UL2017" in sample:
-        module_name = "lepMVA_2017"
-    elif "UL2018" in sample:
-        module_name = "lepMVA_2018"
-    elif ("2022" in sample) or ("2023" in sample):
-        module_name = "lepMVA"
-    else:
-        module_name = "lepMVA_2016"
-
-    # dataset selection (mode-dependent)
     if INPUT_MODE == "dbs":
         ds = cmssw.Dataset(
             dataset=jsn["path"],
-            lumis_per_task=1,   # since file_based=True, this is effectively files_per_task
+            lumis_per_task=1,
             file_based=True,
         )
     else:
@@ -193,8 +215,6 @@ for sample in sorted(cfg["jsons"]):
     cmd += ["--module", module_name]
     cmd += ["--out-dir", "."]
     cmd += ["@inputfiles"]
-
-    print("\nRemote command:\n", " ".join(cmd), "\n")
 
     skim_wf = Workflow(
         label=sample.replace("-", "_"),

--- a/skimmer/lobster_profiles.md
+++ b/skimmer/lobster_profiles.md
@@ -1,0 +1,13 @@
+# Lobster profiles
+
+This file defines profile defaults used by `skimmer/lobster_config.py`.
+
+## run2_el9_skims
+- year: 2018
+- tag: data/NAOD_ULv12_lepMVA-run2/2018
+- cfg_name: ND_UL18_background_samples.cfg
+
+## run3_mva_anpicci
+- year: 2022
+- tag: data/NAOD_ULv12_lepMVA-run3/2022
+- cfg_name: ND_2022_background_samples.cfg

--- a/skimmer/lobster_profiles.md
+++ b/skimmer/lobster_profiles.md
@@ -6,8 +6,10 @@ This file defines profile defaults used by `skimmer/lobster_config.py`.
 - year: 2018
 - tag: data/NAOD_ULv12_lepMVA-run2/2018
 - cfg_name: ND_UL18_background_samples.cfg
+- sandbox_release: CMSSW_10_6_19_patch2
 
 ## run3_mva_anpicci
 - year: 2022
 - tag: data/NAOD_ULv12_lepMVA-run3/2022
 - cfg_name: ND_2022_background_samples.cfg
+- sandbox_release: CMSSW_14_0_6

--- a/skimmer/lobster_profiles.md
+++ b/skimmer/lobster_profiles.md
@@ -4,12 +4,20 @@ This file defines profile defaults used by `skimmer/lobster_config.py`.
 
 ## run2_el9_skims
 - year: 2018
+- step: skims
+- type: background
+- target: SR
 - tag: data/NAOD_ULv12_lepMVA-run2/2018
 - cfg_name: ND_UL18_background_samples.cfg
 - sandbox_release: CMSSW_10_6_19_patch2
+- default_module: lepMVA_2018
 
 ## run3_mva_anpicci
-- year: 2022
-- tag: data/NAOD_ULv12_lepMVA-run3/2022
-- cfg_name: ND_2022_background_samples.cfg
+- year: 2023BPix
+- step: skimmed
+- type: background
+- target: SR
+- tag: background/NAOD_ULv12_lepMVA-run3/2023BPix
+- cfg_name: ND_2023BPix_background_samples.cfg
 - sandbox_release: CMSSW_14_0_6
+- default_module: lepMVA_2016


### PR DESCRIPTION
### Motivation
- Make the default setup profiles match requested Run2/Run3 settings and allow explicit control over the CMGTools and PhysicsTools/NanoAODTools clone sources used when setting up CMSSW. 
- Keep setup configuration auditable and overrideable via an optional markdown file so repo-level presets drive automated setup.

### Description
- Change `run2_el9_skims` defaults to `CMSSW_10_6_19_patch2` with `slc7_amd64_gcc700`, and keep `run3_mva_anpicci` on `CMSSW_14_0_6`/`el9_amd64_gcc12`, by updating `setup.py` and `setup_profiles.md` fallback values. 
- Add `cmgtools_url`, `cmgtools_branch`, `nanoaodtools_url`, and `nanoaodtools_branch` to `SETUP_PROFILES` and loadable `setup_profiles.md`, and wire those values through `setup.py` into the install step. 
- Update `scripts/install_cmssw.sh` to accept the extra clone-source arguments and to clone CMGTools and NanoAODTools into the CMSSW area using the configured URL/branch (branch optional). 
- Document the new profile keys and behavior in `README.md` and the new `docs/run2_run3_integration.md`, and add `skimmer/lobster_profiles.md` for runtime profile defaults while refactoring `skimmer/lobster_config.py` profile loading/selection.

### Testing
- Compiled Python files with `python -m py_compile setup.py skimmer/lobster_config.py skimmer/skim_wrapper.py`, which completed successfully. 
- Checked shell syntax of the installer with `bash -n scripts/install_cmssw.sh`, which completed successfully. 
- Verified repository changes and commit via `git status`/`git log` commands (local commit created successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995c12d0be483238bf011cfbf50ac63)